### PR TITLE
adding l1 cache at client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +326,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,20 +366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +385,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -540,12 +576,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -807,6 +837,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +888,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -938,6 +994,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -1137,8 +1199,8 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
- "dashmap",
  "futures",
+ "moka",
  "parking_lot",
  "prost",
  "rand 0.10.0",
@@ -1328,6 +1390,12 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -1633,6 +1701,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +540,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1117,6 +1137,7 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
+ "dashmap",
  "futures",
  "parking_lot",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.31"
 rand = "0.10.0"
 clap = { version = "4.5.58", features = ["derive"] }
 bytes = "1.10.0"
-dashmap = "6.0.0"
+moka = { version = "0.12", features = ["future"] }
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3.31"
 rand = "0.10.0"
 clap = { version = "4.5.58", features = ["derive"] }
 bytes = "1.10.0"
+dashmap = "6.0.0"
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/src/cluster/distributed_client.rs
+++ b/src/cluster/distributed_client.rs
@@ -24,6 +24,7 @@ pub struct DistributedClient {
     clients: Arc<RwLock<HashMap<String, RemoteCacheClient>>>,
     ring: Arc<RwLock<HashRing>>,
     client_config: ClusterClientConfig
+    
 }
 
 impl DistributedClient {

--- a/src/transport/grpc/client.rs
+++ b/src/transport/grpc/client.rs
@@ -9,13 +9,14 @@ use crate::proto::{GetRequest,PutRequest,DeleteRequest,StatsRequest};
 use crate::proto::red_stone_client::RedStoneClient;
 use crate::tensor::meta::{DType, StorageLayout, TensorMeta};
 use crate::tensor::tensor::Tensor;
+use dashmap::DashMap;
 
 #[derive(Clone)]
 pub struct RemoteCacheClient {
-    // each client-server connection has a separate channel. total number of channels are equal
-    // to the number of servers
+    // each client-server connection has a separate channel.
     clients: Arc<Vec<RedStoneClient<Channel>>>,
     next: Arc<AtomicUsize>,
+    l1_cache: Arc<DashMap<String,Arc<Tensor>>>
 }
 
 const POOL_SIZE: usize = 10;
@@ -34,12 +35,21 @@ impl RemoteCacheClient {
             clients.push(client);
         }
 
-        Ok(Self { clients: Arc::new(clients), next: Arc::new(AtomicUsize::new(0))})
+        Ok(Self {
+            clients: Arc::new(clients),
+            next: Arc::new(AtomicUsize::new(0)),
+            l1_cache: Arc::new(DashMap::new())
+        })
     }
 
     pub async fn get(&self, key: String) -> Result<Option<Arc<Tensor>>, ClientError> {
 
+        //first check if key exists in client cache, if not, send the request to server.
+        if let Some(tensor) = self.l1_cache.get(&key) {
+            return Ok(Some(tensor.clone()));
+        }
         let request = tonic::Request::new(GetRequest { key });
+        let key = request.get_ref().key.clone();
         let mut client = self.client();
         match client.get(request).await {
             Ok(response) => {
@@ -62,10 +72,10 @@ impl RemoteCacheClient {
                 let proto_meta = meta.ok_or_else(|| ClientError::ServerError("Missing metadata".into()))?;
 
                 let meta = proto_to_meta(&proto_meta)?;
-
                 let tensor = Tensor::new(meta, buffer.freeze()).map_err(|_| ClientError::ServerError("Invalid tensor data".into()))?;
-
-                Ok(Some(Arc::new(tensor)))
+                let tensor = Arc::new(tensor);
+                self.l1_cache.insert(key.clone(), tensor.clone());
+                Ok(Some(tensor))
             }
 
             Err(status) => match status.code() {
@@ -82,19 +92,27 @@ impl RemoteCacheClient {
     }
 
     pub async fn put(&self, key: String, meta: TensorMeta, data: Vec<u8>) -> Result<(), ClientError> {
-        let proto_meta = proto::TensorMeta { dtype: dtype_to_proto(meta.dtype()),
+        let proto_meta = proto::TensorMeta {
+            dtype: dtype_to_proto(meta.dtype()),
             shape: meta.shape().iter().map(|&s| s as u64).collect(),
             layout: layout_to_proto(meta.layout()),
         };
-        let bytes_data = Bytes::from(data);
+
+        let bytes = Bytes::from(data);
+
+        let tensor = Arc::new(Tensor::new(meta.clone(), bytes.clone())
+                .map_err(|_| ClientError::ServerError("Invalid tensor data".into()))?
+        );
+
         let request = tonic::Request::new(PutRequest {
-            //deep copy has cpu overhead
-            key,
+            key: key.clone(),
             meta: Some(proto_meta),
-            data: bytes_data
+            data: bytes,
         });
+
         let mut client = self.client();
         client.put(request).await?;
+        self.l1_cache.insert(key, tensor);
         Ok(())
     }
 
@@ -102,8 +120,10 @@ impl RemoteCacheClient {
         let request = tonic::Request::new(DeleteRequest {
             key,
         });
+        let key = request.get_ref().key.clone();
         let mut client = self.client();
         client.delete(request).await?;
+        self.l1_cache.remove(&key);
         Ok(())
     }
 

--- a/src/transport/grpc/client.rs
+++ b/src/transport/grpc/client.rs
@@ -1,6 +1,8 @@
+use std::arch::aarch64::uint64x1x2_t;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use bytes::Bytes;
+use clap::builder::Str;
 use tonic::Code;
 use tonic::transport::Channel;
 use crate::error::client_error::ClientError;
@@ -9,17 +11,19 @@ use crate::proto::{GetRequest,PutRequest,DeleteRequest,StatsRequest};
 use crate::proto::red_stone_client::RedStoneClient;
 use crate::tensor::meta::{DType, StorageLayout, TensorMeta};
 use crate::tensor::tensor::Tensor;
-use dashmap::DashMap;
+use moka::future::Cache;
 
 #[derive(Clone)]
 pub struct RemoteCacheClient {
     // each client-server connection has a separate channel.
     clients: Arc<Vec<RedStoneClient<Channel>>>,
     next: Arc<AtomicUsize>,
-    l1_cache: Arc<DashMap<String,Arc<Tensor>>>
+    l1_cache: Cache<String,Arc<Tensor>>,
 }
 
 const POOL_SIZE: usize = 10;
+//256 bytes l1 cache
+const L1_MAX_BYTES: u64 = 256 * 1024 * 1024;
 impl RemoteCacheClient {
     pub async fn connect(addr: String) -> Result<Self, ClientError> {
         let url = if addr.starts_with("http://") || addr.starts_with("https://") {
@@ -38,14 +42,19 @@ impl RemoteCacheClient {
         Ok(Self {
             clients: Arc::new(clients),
             next: Arc::new(AtomicUsize::new(0)),
-            l1_cache: Arc::new(DashMap::new())
+            l1_cache: Cache::builder()
+                .weigher(|_k: &String, v: &Arc<Tensor>| -> u32 {
+                    v.byte_size() as u32
+                })
+                .max_capacity(L1_MAX_BYTES)
+                .build()
         })
     }
 
     pub async fn get(&self, key: String) -> Result<Option<Arc<Tensor>>, ClientError> {
 
         //first check if key exists in client cache, if not, send the request to server.
-        if let Some(tensor) = self.l1_cache.get(&key) {
+        if let Some(tensor) = self.l1_cache.get(&key).await {
             return Ok(Some(tensor.clone()));
         }
         let request = tonic::Request::new(GetRequest { key });
@@ -74,7 +83,7 @@ impl RemoteCacheClient {
                 let meta = proto_to_meta(&proto_meta)?;
                 let tensor = Tensor::new(meta, buffer.freeze()).map_err(|_| ClientError::ServerError("Invalid tensor data".into()))?;
                 let tensor = Arc::new(tensor);
-                self.l1_cache.insert(key.clone(), tensor.clone());
+                self.l1_cache.insert(key.clone(), tensor.clone()).await;
                 Ok(Some(tensor))
             }
 
@@ -112,7 +121,7 @@ impl RemoteCacheClient {
 
         let mut client = self.client();
         client.put(request).await?;
-        self.l1_cache.insert(key, tensor);
+        self.l1_cache.insert(key, tensor).await;
         Ok(())
     }
 
@@ -123,7 +132,7 @@ impl RemoteCacheClient {
         let key = request.get_ref().key.clone();
         let mut client = self.client();
         client.delete(request).await?;
-        self.l1_cache.remove(&key);
+        self.l1_cache.remove(&key).await;
         Ok(())
     }
 

--- a/src/transport/grpc/client.rs
+++ b/src/transport/grpc/client.rs
@@ -1,8 +1,6 @@
-use std::arch::aarch64::uint64x1x2_t;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use bytes::Bytes;
-use clap::builder::Str;
 use tonic::Code;
 use tonic::transport::Channel;
 use crate::error::client_error::ClientError;
@@ -22,8 +20,8 @@ pub struct RemoteCacheClient {
 }
 
 const POOL_SIZE: usize = 10;
-//256 bytes l1 cache
-const L1_MAX_BYTES: u64 = 256 * 1024 * 1024;
+//256 KB l1 cache
+const L1_MAX_BYTES: u64 = 1024 * 1024;
 impl RemoteCacheClient {
     pub async fn connect(addr: String) -> Result<Self, ClientError> {
         let url = if addr.starts_with("http://") || addr.starts_with("https://") {
@@ -44,7 +42,7 @@ impl RemoteCacheClient {
             next: Arc::new(AtomicUsize::new(0)),
             l1_cache: Cache::builder()
                 .weigher(|_k: &String, v: &Arc<Tensor>| -> u32 {
-                    v.byte_size() as u32
+                    v.byte_size().min(u32::MAX as usize) as u32
                 })
                 .max_capacity(L1_MAX_BYTES)
                 .build()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Introduced a local in-memory L1 cache for remote cache operations; get now prefers the local cache, and put/delete keep the cache synchronized to reduce latency and server round-trips.

* **Chores**
  * Added a new caching dependency to support the in-memory layer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->